### PR TITLE
Update to full_moon 0.13.1 and add `roblox` feature

### DIFF
--- a/extractor/Cargo.lock
+++ b/extractor/Cargo.lock
@@ -18,12 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
 
 [[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,22 +123,25 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "full_moon"
-version = "0.9.0"
-source = "git+https://github.com/Kampfkarren/full-moon?rev=592dcda974d00fad0bd4065b9376375bcf516393#592dcda974d00fad0bd4065b9376375bcf516393"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8b70fda5d9914360039bcbd1e28c980c296c81f38b5fe7d6e004a69703eaa3"
 dependencies = [
  "bytecount",
  "cfg-if",
  "derive_more",
  "full_moon_derive",
- "nom",
  "paste",
+ "peg",
  "serde",
+ "smol_str",
 ]
 
 [[package]]
 name = "full_moon_derive"
-version = "0.5.0"
-source = "git+https://github.com/Kampfkarren/full-moon?rev=592dcda974d00fad0bd4065b9376375bcf516393#592dcda974d00fad0bd4065b9376375bcf516393"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baa95cb901833d1471ca963baa39f1abffdc912798b8a64ac9b364ea98f4725c"
 dependencies = [
  "indexmap",
  "proc-macro2",
@@ -214,19 +211,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec",
- "bitflags",
- "cfg-if",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,12 +221,6 @@ name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
-
-[[package]]
-name = "memchr"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "moonwave"
@@ -257,17 +235,6 @@ dependencies = [
  "serde_json",
  "structopt",
  "walkdir",
-]
-
-[[package]]
-name = "nom"
-version = "5.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
-dependencies = [
- "lexical-core",
- "memchr",
- "version_check",
 ]
 
 [[package]]
@@ -294,6 +261,33 @@ name = "pathdiff"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877630b3de15c0b64cc52f659345724fbf6bdad9bd9566699fc53688f3c34a34"
+
+[[package]]
+name = "peg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c0b841ea54f523f7aa556956fbd293bcbe06f2e67d2eb732b7278aaf1d166a"
+dependencies = [
+ "peg-macros",
+ "peg-runtime",
+]
+
+[[package]]
+name = "peg-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5aa52829b8decbef693af90202711348ab001456803ba2a98eb4ec8fb70844c"
+dependencies = [
+ "peg-runtime",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "peg-runtime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c719dcf55f09a3a7e764c6649ab594c18a177e3599c467983cdf644bfc0a4088"
 
 [[package]]
 name = "pest"
@@ -444,10 +438,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad1d488a557b235fc46dae55512ffbfc429d2482b08b4d9435ab07384ca8aec"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
+name = "smol_str"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+checksum = "b203e79e90905594272c1c97c7af701533d42adaab0beb3859018e477d54a3b0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "strsim"

--- a/extractor/Cargo.toml
+++ b/extractor/Cargo.toml
@@ -18,7 +18,7 @@ opt-level = 1
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-full_moon = { git = "https://github.com/Kampfkarren/full-moon", rev = "592dcda974d00fad0bd4065b9376375bcf516393" }
+full_moon = "0.13.1"
 walkdir = "2"
 anyhow = "1.0.28"
 codespan-reporting = "0.9.5"
@@ -29,3 +29,7 @@ pathdiff = "0.2.0"
 
 [dev-dependencies]
 insta = "1.1.0"
+
+[features]
+default = ["roblox"]
+roblox = ["full_moon/roblox"]

--- a/extractor/src/doc_entry.rs
+++ b/extractor/src/doc_entry.rs
@@ -179,7 +179,7 @@ fn determine_kind(
 impl<'a> DocEntry<'a> {
     pub fn parse(
         doc_comment: &'a DocComment,
-        stmt: Option<&Stmt<'a>>,
+        stmt: Option<&Stmt>,
     ) -> Result<DocEntry<'a>, Diagnostics> {
         let span: Span<'a> = doc_comment.into();
 


### PR DESCRIPTION
Closes #33

This PR updates the moonwave extractor to full_moon version 0.13.1. It's fairly mechanical - the only thing of note is a [breaking change to newline trivia](https://github.com/Kampfkarren/full-moon/pull/125) that makes it necessary to detect consecutive newlines in a slightly different way

It also places Luau syntax support behind a Cargo feature called `roblox` and enables it by default, as most users of moonwave (at least for the time being) are Roblox developers