### PR TITLE
Reimplement sidebar is toggled

### DIFF
--- a/docusaurus-plugin-moonwave/src/components/LuaClass.js
+++ b/docusaurus-plugin-moonwave/src/components/LuaClass.js
@@ -232,7 +232,12 @@ export default function LuaClass({
           )}
         </div>
 
-        <main className={clsx(styles.docMainContainer)}>
+        <main
+          className={clsx(
+            styles.docMainContainer,
+            hiddenSidebar ? styles.docMainContainerEnhanced : ""
+          )}
+        >
           <div className={clsx("container padding-vert--lg")}>
             <div className="row" style={{ flexWrap: "nowrap" }}>
               <div className={`col ${styles.docItemCol}`}>

--- a/docusaurus-plugin-moonwave/src/components/styles.module.css
+++ b/docusaurus-plugin-moonwave/src/components/styles.module.css
@@ -388,7 +388,7 @@
   }
 
   .docMainContainerEnhanced {
-    max-width: none;
+    max-width: calc(100% - var(--doc-sidebar-hidden-width));
   }
 
   .docSidebarContainer {


### PR DESCRIPTION
Docusaurus handles this interaction internally, but our <main> tag doesn't get the .docMainContainerEnhanced class when the sidebar is toggled. This change creates the class in the css module and applies it conditionally

Closes #31 