### PR TITLE
Sidebar Does Not Collapse

### DIFF
--- a/docusaurus-plugin-moonwave/src/components/styles.module.css
+++ b/docusaurus-plugin-moonwave/src/components/styles.module.css
@@ -401,7 +401,9 @@
   }
 
   .docSidebarContainerHidden {
-    width: var(--doc-sidebar-hidden-width);
+    width: var(
+      --doc-sidebar-hidden-width
+    ) !important; /* When the project is built, the width from the previous class is prioritized in the bundler so we have to override it */
     cursor: pointer;
   }
 


### PR DESCRIPTION
When the project is built, the width from the previous class is prioritized in the bundler so we have to override it

Closes #32