### PR TITLE
Allow custom sidebars with sidebars.js

### DIFF
--- a/cli/src/getDocusaurusConfig.ts
+++ b/cli/src/getDocusaurusConfig.ts
@@ -7,7 +7,7 @@ export interface GenerateConfigParams {
   enablePlugins: FoldersEnabled
   config: Config
   customCssExists: boolean
-  customSidebarsExists: boolean
+  customSidebarExists: boolean
   changelogExists: boolean
   projectDir: string
   binaryPath: string
@@ -19,7 +19,7 @@ export default function getDocusaurusConfig({
   enablePlugins,
   config,
   customCssExists,
-  customSidebarsExists,
+  customSidebarExists,
   changelogExists,
   projectDir,
   binaryPath,

--- a/cli/src/getDocusaurusConfig.ts
+++ b/cli/src/getDocusaurusConfig.ts
@@ -112,7 +112,9 @@ export default function getDocusaurusConfig({
                   ? `${gitRepoUrl}/edit/${config.gitSourceBranch ?? "master"}/`
                   : undefined, // Omitting this variable entirely will disable edit links
                 sidebarCollapsible: true,
-                sidebarPath: customSidebarsExists ? "./src/sidebars.js" : undefined
+                sidebarPath: customSidebarsExists
+                  ? "./src/sidebars.js"
+                  : undefined,
               }
             : false,
           blog: enablePlugins.blog

--- a/cli/src/getDocusaurusConfig.ts
+++ b/cli/src/getDocusaurusConfig.ts
@@ -7,6 +7,7 @@ export interface GenerateConfigParams {
   enablePlugins: FoldersEnabled
   config: Config
   customCssExists: boolean
+  customSidebarsExists: boolean
   changelogExists: boolean
   projectDir: string
   binaryPath: string
@@ -18,6 +19,7 @@ export default function getDocusaurusConfig({
   enablePlugins,
   config,
   customCssExists,
+  customSidebarsExists,
   changelogExists,
   projectDir,
   binaryPath,
@@ -110,6 +112,7 @@ export default function getDocusaurusConfig({
                   ? `${gitRepoUrl}/edit/${config.gitSourceBranch ?? "master"}/`
                   : undefined, // Omitting this variable entirely will disable edit links
                 sidebarCollapsible: true,
+                sidebarPath: customSidebarsExists ? "./src/sidebars.js" : undefined
               }
             : false,
           blog: enablePlugins.blog

--- a/cli/src/prepareProject.ts
+++ b/cli/src/prepareProject.ts
@@ -240,29 +240,29 @@ function copyChangelog(
 function copyMoonwaveFolder(
   projectDir: string,
   tempDir: string
-): { customCssExists: boolean, customSidebarsExists: boolean } {
+): { customCssExists: boolean, customSidebarExists: boolean } {
   const staticDir = path.join(projectDir, ".moonwave", "static")
   if (fs.existsSync(staticDir)) {
     fs.copySync(staticDir, path.join(tempDir, "static"))
   }
 
-  let customCssExists = false, customSidebarsExists = false;
+  const status = {customCssExists: false, customSidebarExists: false};
 
   const customCssPath = path.join(projectDir, ".moonwave", "custom.css")
   if (fs.existsSync(customCssPath)) {
     fs.copySync(customCssPath, path.join(tempDir, "src", "css", "custom.css"))
 
-    customCssExists = true;
+    status.customCssExists = true;
   }
 
   const customSidebarsPath = path.join(projectDir, ".moonwave", "sidebars.js")
   if (fs.existsSync(customSidebarsPath)) {
     fs.copySync(customSidebarsPath, path.join(tempDir, "src", "sidebars.js"))
 
-    customSidebarsExists = true;
+    status.customSidebarExists = true;
   }
 
-  return { customCssExists, customSidebarsExists }
+  return status;
 }
 
 function writeDocusaurusConfig(tempDir: string, params: GenerateConfigParams) {
@@ -370,13 +370,13 @@ export function prepareProject(
 
   const foundFolders = copyContentFolders(projectDir, tempDir)
 
-  const { customCssExists, customSidebarsExists } = copyMoonwaveFolder(projectDir, tempDir)
+  const { customCssExists, customSidebarExists } = copyMoonwaveFolder(projectDir, tempDir)
 
   const docusaurusConfigModified = writeDocusaurusConfig(tempDir, {
     config,
     enablePlugins: foundFolders,
     customCssExists,
-    customSidebarsExists,
+    customSidebarExists,
     codePaths: options.codePaths,
     binaryPath: options.binaryPath,
     changelogExists,

--- a/cli/src/prepareProject.ts
+++ b/cli/src/prepareProject.ts
@@ -6,7 +6,7 @@ import path, { dirname } from "path"
 import toml from "toml"
 import { fileURLToPath } from "url"
 import getDocusaurusConfig, {
-  GenerateConfigParams,
+  GenerateConfigParams
 } from "./getDocusaurusConfig.js"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -240,20 +240,29 @@ function copyChangelog(
 function copyMoonwaveFolder(
   projectDir: string,
   tempDir: string
-): { customCssExists: boolean } {
+): { customCssExists: boolean, customSidebarsExists: boolean } {
   const staticDir = path.join(projectDir, ".moonwave", "static")
   if (fs.existsSync(staticDir)) {
     fs.copySync(staticDir, path.join(tempDir, "static"))
   }
 
+  let customCssExists = false, customSidebarsExists = false;
+
   const customCssPath = path.join(projectDir, ".moonwave", "custom.css")
   if (fs.existsSync(customCssPath)) {
     fs.copySync(customCssPath, path.join(tempDir, "src", "css", "custom.css"))
 
-    return { customCssExists: true }
+    customCssExists = true;
   }
 
-  return { customCssExists: false }
+  const customSidebarsPath = path.join(projectDir, ".moonwave", "sidebars.js")
+  if (fs.existsSync(customSidebarsPath)) {
+    fs.copySync(customSidebarsPath, path.join(tempDir, "src", "sidebars.js"))
+
+    customSidebarsExists = true;
+  }
+
+  return { customCssExists, customSidebarsExists }
 }
 
 function writeDocusaurusConfig(tempDir: string, params: GenerateConfigParams) {
@@ -361,12 +370,13 @@ export function prepareProject(
 
   const foundFolders = copyContentFolders(projectDir, tempDir)
 
-  const { customCssExists } = copyMoonwaveFolder(projectDir, tempDir)
+  const { customCssExists, customSidebarsExists } = copyMoonwaveFolder(projectDir, tempDir)
 
   const docusaurusConfigModified = writeDocusaurusConfig(tempDir, {
     config,
     enablePlugins: foundFolders,
     customCssExists,
+    customSidebarsExists,
     codePaths: options.codePaths,
     binaryPath: options.binaryPath,
     changelogExists,

--- a/cli/src/prepareProject.ts
+++ b/cli/src/prepareProject.ts
@@ -6,7 +6,7 @@ import path, { dirname } from "path"
 import toml from "toml"
 import { fileURLToPath } from "url"
 import getDocusaurusConfig, {
-  GenerateConfigParams
+  GenerateConfigParams,
 } from "./getDocusaurusConfig.js"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -240,29 +240,29 @@ function copyChangelog(
 function copyMoonwaveFolder(
   projectDir: string,
   tempDir: string
-): { customCssExists: boolean, customSidebarExists: boolean } {
+): { customCssExists: boolean; customSidebarExists: boolean } {
   const staticDir = path.join(projectDir, ".moonwave", "static")
   if (fs.existsSync(staticDir)) {
     fs.copySync(staticDir, path.join(tempDir, "static"))
   }
 
-  const status = {customCssExists: false, customSidebarExists: false};
+  const status = { customCssExists: false, customSidebarExists: false }
 
   const customCssPath = path.join(projectDir, ".moonwave", "custom.css")
   if (fs.existsSync(customCssPath)) {
     fs.copySync(customCssPath, path.join(tempDir, "src", "css", "custom.css"))
 
-    status.customCssExists = true;
+    status.customCssExists = true
   }
 
   const customSidebarsPath = path.join(projectDir, ".moonwave", "sidebars.js")
   if (fs.existsSync(customSidebarsPath)) {
     fs.copySync(customSidebarsPath, path.join(tempDir, "src", "sidebars.js"))
 
-    status.customSidebarExists = true;
+    status.customSidebarExists = true
   }
 
-  return status;
+  return status
 }
 
 function writeDocusaurusConfig(tempDir: string, params: GenerateConfigParams) {
@@ -370,7 +370,10 @@ export function prepareProject(
 
   const foundFolders = copyContentFolders(projectDir, tempDir)
 
-  const { customCssExists, customSidebarExists } = copyMoonwaveFolder(projectDir, tempDir)
+  const { customCssExists, customSidebarExists } = copyMoonwaveFolder(
+    projectDir,
+    tempDir
+  )
 
   const docusaurusConfigModified = writeDocusaurusConfig(tempDir, {
     config,

--- a/website/docs/StaticFiles.md
+++ b/website/docs/StaticFiles.md
@@ -65,4 +65,4 @@ module.exports = {
 };
 ```
 
-Additional information on customizing your `docs` sidebar can be found at [the Docusaurus Documentation](https://docusaurus.io/docs/sidebar)
+Additional information on customizing your `docs` sidebar can be found at [the Docusaurus Documentation](https://docusaurus.io/docs/sidebar).

--- a/website/docs/StaticFiles.md
+++ b/website/docs/StaticFiles.md
@@ -2,7 +2,7 @@
 sidebar_position: 5
 ---
 
-# Static Files and Custom CSS
+# Static Files and Custom Configurations
 
 You can further customize Moonwave by creating a `.moonwave` folder in your root directory.
 
@@ -35,3 +35,34 @@ You can create a file at `.moonwave/custom.css`. Here's an example of what you c
   --ifm-code-font-size: 95%;
 }
 ```
+
+## Custom Docs Sidebar
+
+You can create a custom `.moonwave/sidebars.js` file to set up a custom layout for your `docs` pages. This allows you to specifiy ordering, sections, and even if certain files are excluded.
+
+Example `sidebar.js` file:
+
+```js
+module.exports = {
+  mySidebar: [
+    {
+        type: "doc",
+        id: "getting-started"
+        label: "Getting Started"
+    },
+    {
+      type: 'category',
+      label: 'Moonwave',
+      items: ['moonwave-basics, moonwave-advances'],
+    },
+    {
+      type: 'category',
+      label: 'Other Resources',
+      items: ['nested-folder/extra-resources', 'another-folder/even-more-resources'],
+    },
+
+  ],
+};
+```
+
+Additional information on customizing your `docs` sidebar can be found at (the Docusaurus Documentation)[https://docusaurus.io/docs/sidebar]

--- a/website/docs/StaticFiles.md
+++ b/website/docs/StaticFiles.md
@@ -2,7 +2,7 @@
 sidebar_position: 5
 ---
 
-# Static Files and Custom Configurations
+# Static Files
 
 You can further customize Moonwave by creating a `.moonwave` folder in your root directory.
 
@@ -38,9 +38,9 @@ You can create a file at `.moonwave/custom.css`. Here's an example of what you c
 
 ## Custom Docs Sidebar
 
-You can create a custom `.moonwave/sidebars.js` file to set up a custom layout for your `docs` pages. This allows you to specifiy ordering, sections, and even if certain files are excluded.
+You can create a custom `.moonwave/sidebars.js` file to set up a custom ordering for your `docs` sidebar. This allows you to specify ordering, sections, and if certain files are excluded.
 
-Example `sidebar.js` file:
+Example `sidebars.js` file:
 
 ```js
 module.exports = {
@@ -65,4 +65,4 @@ module.exports = {
 };
 ```
 
-Additional information on customizing your `docs` sidebar can be found at (the Docusaurus Documentation)[https://docusaurus.io/docs/sidebar]
+Additional information on customizing your `docs` sidebar can be found at [the Docusaurus Documentation](https://docusaurus.io/docs/sidebar)

--- a/website/docs/StaticFiles.md
+++ b/website/docs/StaticFiles.md
@@ -46,23 +46,25 @@ Example `sidebars.js` file:
 module.exports = {
   mySidebar: [
     {
-        type: "doc",
-        id: "getting-started"
-        label: "Getting Started"
+      type: "doc",
+      id: "getting-started",
+      label: "Getting Started",
     },
     {
-      type: 'category',
-      label: 'Moonwave',
-      items: ['moonwave-basics, moonwave-advances'],
+      type: "category",
+      label: "Moonwave",
+      items: ["moonwave-basics, moonwave-advances"],
     },
     {
-      type: 'category',
-      label: 'Other Resources',
-      items: ['nested-folder/extra-resources', 'another-folder/even-more-resources'],
+      type: "category",
+      label: "Other Resources",
+      items: [
+        "nested-folder/extra-resources",
+        "another-folder/even-more-resources",
+      ],
     },
-
   ],
-};
+}
 ```
 
 Additional information on customizing your `docs` sidebar can be found at [the Docusaurus Documentation](https://docusaurus.io/docs/sidebar).


### PR DESCRIPTION
 The user can place a custom `sidebar.js` file in the `.moonwave` folder to organize their `docs` as they wish. This folder is then loaded in the same manner as a `custom.css` file when the plugin is run. The export format follows exactly as per the Docusaurus documentation https://docusaurus.io/docs/sidebar. All Docusaurus errors carry foward for format, structure, and missing markdown file references. If a user does not create a `sidebar.js` file, a default `docs` sidebar is generated

Closes #9 