### PR TITLE
Moonwave incorrectly displays code block titles

### DIFF
--- a/docusaurus-plugin-moonwave/src/components/styles.module.css
+++ b/docusaurus-plugin-moonwave/src/components/styles.module.css
@@ -238,6 +238,7 @@
 
 :global pre[class*="language-"][class*="language-"] {
   padding: 1rem;
+  margin: 0;
 }
 
 :global code[class*="language-"][class*="language-"] {


### PR DESCRIPTION
The default Docusaurus stylesheet incorrectly applies a margin that wasn't being overwritten correctly. Now functionality matches to our site. Closes #70 