### PR TITLE
Toggle Docusaurus system theme config option on new projects

### DIFF
--- a/cli/src/getDocusaurusConfig.ts
+++ b/cli/src/getDocusaurusConfig.ts
@@ -87,6 +87,10 @@ export default function getDocusaurusConfig({
         }. Built with Moonwave and Docusaurus.`,
         ...config.footer,
       },
+
+      colorMode: {
+        respectPrefersColorScheme: true,
+      },
     },
     plugins: [
       [


### PR DESCRIPTION
- Docusaurus has a built in hook in the `docusaurus.config.js` file that allows you to not only set the color theme, but specify if it should respect the user's default system theme

```js
{
	themeConfig: {
	colorMode: {
	        respectPrefersColorScheme: true,
	      },
	}
}
```