### PR TITLE
Support repos whose origin is ssh instead of http

### DIFF
--- a/cli/src/prepareProject.ts
+++ b/cli/src/prepareProject.ts
@@ -122,12 +122,6 @@ function getConfig(projectDir: string): Config {
   const [, repoAuthor, repoName] =
     gitRepoUrl?.match(/^https?:\/\/.+\/(.+)\/(.+)$/) || []
 
-  const testInfo = {
-    gitRepoUrl,
-    repoAuthor,
-    repoName,
-  }
-
   const config = readConfig(projectDir)
 
   // Note: Only copying values from other places in the config should go here.

--- a/cli/src/prepareProject.ts
+++ b/cli/src/prepareProject.ts
@@ -119,7 +119,9 @@ function getConfig(projectDir: string): Config {
   // Default values for docusaurus.config.js belong in getDocusaurusConfig
   return {
     title: repoName,
-    gitRepoUrl,
+    gitRepoUrl: gitRepoUrl?.includes("git@")
+      ? `https://github.com/${repoAuthor}/${repoName}`
+      : gitRepoUrl,
     changelog: true,
     ...config,
 


### PR DESCRIPTION
Manually overrides gitRepoUrl when non HTTPS detected. This approach accounts for when folks initialize their repo with a remote origin that begins with a `git@` prefix, which was first reported by users using SSH origins. The error is that on certain `<a>` tags the SSH url cannot be interpreted as valid. This change builds a manual url to remedy that.

Closes #72 