### PR TITLE
Remove package-lock.json diff check

### DIFF
--- a/cli/src/prepareProject.ts
+++ b/cli/src/prepareProject.ts
@@ -339,17 +339,6 @@ function needsCompleteRebuild(tempDir: string): boolean {
     return true
   }
 
-  if (
-    !fs
-      .readFileSync(path.join(ROOT_PATH, "package-lock.json"))
-      .equals(fs.readFileSync(path.join(tempDir, "package-lock.json")))
-  ) {
-    console.log(
-      "Moonwave: package-lock.json differs from cached files, rebuilding..."
-    )
-    return true
-  }
-
   return false
 }
 


### PR DESCRIPTION
It seems like npm install likes to rewrite package-lock.json, and everything is probably covered in our package.json diff check anyways. Removing this should prevent unnecessary reinstalls.